### PR TITLE
TNT-3043 push image to github container registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           push: true
           tags: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,5 +30,6 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/babbel/ruru-lambda:${{ github.event.release.tag_name }}
+            ghcr.io/babbel/ruru-lambda:latest
             ghcr.io/babbel/ruru-lambda:build-ruby2.7
+            ghcr.io/babbel/ruru-lambda:${{ github.event.release.tag_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,11 +17,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         id: docker_build
@@ -29,6 +30,6 @@ jobs:
         with:
           push: true
           tags: |
-            driv3r/ruru-lambda:latest
-            driv3r/ruru-lambda:build-ruby2.7
-            driv3r/ruru-lambda:${{ github.event.release.tag_name }}
+            ghcr.io/babbel/ruru-lambda:latest
+            ghcr.io/babbel/ruru-lambda:build-ruby2.7
+            ghcr.io/babbel/ruru-lambda:${{ github.event.release.tag_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   push_to_registry:
-    name: Push Docker image to Docker Hub
+    name: Push Docker image to Github Registry
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to GitHub Container Registry
+      - name: Login to Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,5 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/babbel/ruru-lambda:latest
-            ghcr.io/babbel/ruru-lambda:build-ruby2.7
             ghcr.io/babbel/ruru-lambda:${{ github.event.release.tag_name }}
+            ghcr.io/babbel/ruru-lambda:build-ruby2.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           push: true
           tags: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Login to Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: false
+          push: true
+          tags: |
+            ghcr.io/babbel/ruru-lambda:latest
+            ghcr.io/babbel/ruru-lambda:build-ruby2.7
+            ghcr.io/babbel/ruru-lambda:${{ github.event.release.tag_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,4 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v4
         with:
-          push: true
-          tags: |
-            ghcr.io/babbel/ruru-lambda:latest
-            ghcr.io/babbel/ruru-lambda:build-ruby2.7
-            ghcr.io/babbel/ruru-lambda:${{ github.event.release.tag_name }}
+          push: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on: push
 
 jobs:
   push_to_registry:
-    name: Push Docker image to Docker Hub
+    name: Push Docker image to Container Registry
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo


### PR DESCRIPTION
After we forked the repo we want to publish the docker image to the github container registry. 
